### PR TITLE
ci: set up actions workflow for tests and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  PHP_VERSION: 8.3
+  PHP_EXTENSIONS: mbstring,pdo,xml,ctype,fileinfo,json,curl,openssl,dom,zip
+  PHP_INI_PROPERTIES: post_max_size=256M,upload_max_filesize=256M
+
+jobs:
+  setup:
+    name: Setup PHP
+    runs-on: ubuntu-24.04
+    outputs:
+      combined-key: ${{ steps.prepare-env.outputs.combined-key }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Prepare environment and composer data
+        id: prepare-env
+        run: |
+          composer_dir=$(composer config cache-files-dir)
+          composer_hash=${{ hashFiles('**/composer.lock') }}
+          os_lower=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')
+          arch_lower=$(echo ${{ runner.arch }} | tr '[:upper:]' '[:lower:]')
+          combined_key="${os_lower}-${arch_lower}-composer-${composer_hash}"
+          echo "combined-key=${combined_key}" >> "$GITHUB_OUTPUT"
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          extensions: ${{ env.PHP_EXTENSIONS }}
+          ini-values: ${{ env.PHP_INI_PROPERTIES }}
+      - name: Install composer dependencies
+        uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--optimize-autoloader --prefer-dist"
+          custom-cache-key: ${{ steps.prepare-env.outputs.combined-key }}
+  lint:
+    name: Perform lint
+    runs-on: ubuntu-24.04
+    needs: setup
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          extensions: ${{ env.PHP_EXTENSIONS }}
+          ini-values: ${{ env.PHP_INI_PROPERTIES }}
+      - name: Install composer dependencies
+        uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--optimize-autoloader --prefer-dist"
+          custom-cache-key: ${{ needs.setup.outputs.combined-key }}
+      - name: Run Pint
+        run: ./vendor/bin/pint --no-interaction --test --preset=laravel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,69 @@ jobs:
           custom-cache-key: ${{ needs.setup.outputs.combined-key }}
       - name: Run Pint
         run: ./vendor/bin/pint --no-interaction --test --preset=laravel
+  tests:
+    name: Run tests
+    runs-on: ubuntu-24.04
+    needs: setup
+    env:
+      BROADCAST_DRIVER: log
+      CACHE_DRIVER: redis
+      QUEUE_CONNECTION: redis
+      SESSION_DRIVER: redis
+      DB_CONNECTION: pgsql
+      DB_HOST: localhost
+      DB_PASSWORD: postgres
+      DB_USERNAME: postgres
+      DB_DATABASE: postgres
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: app
+        ports:
+          - 5432/tcp
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis
+        ports:
+          - 6379/tcp
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          extensions: ${{ env.PHP_EXTENSIONS }}
+          ini-values: ${{ env.PHP_INI_PROPERTIES }}
+          coverage: 'xdebug'
+      - name: Install composer dependencies
+        uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--optimize-autoloader --prefer-dist"
+          custom-cache-key: ${{ needs.setup.outputs.combined-key }}
+      - name: Prepare the application
+        run: |
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate
+      - name: Run Migration
+        run: php artisan migrate --seed -v
+        env:
+          DB_PORT: ${{ job.services.postgres.ports['5432'] }}
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+      - name: Run feature tests
+        run: php artisan test
+        env:
+          DB_PORT: ${{ job.services.postgres.ports['5432'] }}
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
       - main
       - develop
   workflow_dispatch:
+    inputs:
+      coverage:
+        description: 'Run with coverage tests'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -124,14 +130,21 @@ jobs:
       - name: Prepare the application
         run: |
           php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan config:clear
           php artisan key:generate
       - name: Run Migration
         run: php artisan migrate --seed -v
         env:
           DB_PORT: ${{ job.services.postgres.ports['5432'] }}
           REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
-      - name: Run feature tests
+      - name: Run tests
         run: php artisan test
+        env:
+          DB_PORT: ${{ job.services.postgres.ports['5432'] }}
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+      - name: Run coverage tests
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.coverage }}
+        run: php artisan test --coverage --min=90
         env:
           DB_PORT: ${{ job.services.postgres.ports['5432'] }}
           REDIS_PORT: ${{ job.services.redis.ports['6379'] }}

--- a/app/Http/Controllers/Api/V1/OAuthController.php
+++ b/app/Http/Controllers/Api/V1/OAuthController.php
@@ -21,7 +21,6 @@ class OAuthController extends Controller
             ? now()->addSeconds($socialUser->expiresIn)
             : null;
 
-
         // Create a user or log them in...
         $connectedAccount = ConnectedAccount::firstOrNew([
             'provider' => $provider,

--- a/app/Models/Settings/Settings.php
+++ b/app/Models/Settings/Settings.php
@@ -21,11 +21,12 @@ class Settings extends Model
     ];
 
     protected $casts = [
-        'is_developer' => 'boolean'
+        'is_developer' => 'boolean',
     ];
 
-    public function getPronounsAttribute() {
-        return config('extension.pronouns.' . $this->attributes['pronouns']);
+    public function getPronounsAttribute()
+    {
+        return config('extension.pronouns.'.$this->attributes['pronouns']);
     }
 
     public function user(): BelongsTo

--- a/tests/Feature/Http/Controllers/Api/V1/AuthenticatedUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/V1/AuthenticatedUserControllerTest.php
@@ -47,7 +47,7 @@ class AuthenticatedUserControllerTest extends TestCase
             ->putJson(route('auth.update-settings'), $payload);
 
         // Assert
-        $payload['pronouns'] = config('extension.pronouns.' . $payload['pronouns']);
+        $payload['pronouns'] = config('extension.pronouns.'.$payload['pronouns']);
         $response->assertOk()
             ->assertJsonFragment($payload)
             ->assertJsonStructure(['occupation' => ['id']])

--- a/tests/Feature/Http/Controllers/Api/V1/AuthenticatedUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/V1/AuthenticatedUserControllerTest.php
@@ -2,13 +2,14 @@
 
 namespace Tests\Feature\Http\Controllers\Api\V1;
 
+use App\Clients\Consumer\ConsumerClient;
 use App\Models\User;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class AuthenticatedUserControllerTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     protected function setUp(): void
     {
@@ -19,8 +20,19 @@ class AuthenticatedUserControllerTest extends TestCase
     {
         // Arrange
         $this->artisan('db:seed');
-        $user = User::factory()
-            ->create();
+        $user = User::factory()->create();
+
+        /**
+         * I don't think the right way would be to run a docker compose with
+         * the Rust + ScyllaDB (and also Postgres, Redis) just to run the tests,
+         * at the same time I'm not a php dev, so there may well be a better solution for this.
+         */
+        $this->partialMock(ConsumerClient::class, function ($mock) use ($user) {
+            $mock->shouldReceive('updateUser')
+                ->once()
+                ->with($user)
+                ->andReturn(true);
+        });
 
         $user->accounts()->create([
             'provider' => 'twitch',


### PR DESCRIPTION
### Summary

This PR introduces a Continuous Integration (CI) pipeline using GitHub Actions to automate testing and linting processes in the Laravel project.

- Code Linting: Integrates Laravel Pint to enforce code standards.
- Automated Tests: Runs tests on push and pull request events to main and develop branches, using PostgreSQL and Redis services.
- Optional Coverage: Adds support for generating code coverage reports via manual workflow dispatch.


> [!NOTE]
> The `AuthenticatedUserControllerTest` file includes a partial mock of the `ConsumerClient` class to facilitate testing without requiring the full Docker Compose setup with Rust, ScyllaDB, PostgreSQL, and Redis. While this approach works, there may be more ["correct" solutions](https://laravel.com/docs/11.x/http-client#faking-responses) that I couldn't implement.