### PR TITLE
feat: sync authentication token with tbp-consumer-api

### DIFF
--- a/app/Clients/Consumer/ConsumerClient.php
+++ b/app/Clients/Consumer/ConsumerClient.php
@@ -2,6 +2,7 @@
 
 namespace App\Clients\Consumer;
 
+use App\Clients\Consumer\DTO\UserTokenDTO;
 use App\Models\Settings\Settings;
 use App\Models\User;
 use ChrisReedIO\Socialment\Models\ConnectedAccount;
@@ -51,6 +52,24 @@ class ConsumerClient
 
         if ($response->getStatusCode() !== 200) {
             throw new ConsumerClientException('Failed to update user settings');
+        }
+    }
+
+    public function sendUserToken(UserTokenDTO $tokenDTO): void
+    {
+        $uri = $this->baseVersionedUrl.'/authenticate';
+
+        $payload = [
+            'user_id' => $tokenDTO->userId,
+            'token' => $tokenDTO->authDTO->accessToken,
+        ];
+
+        $response = $this->client->post($uri, [
+            'json' => $payload,
+        ]);
+
+        if ($response->getStatusCode() !== 201) {
+            throw new ConsumerClientException('Failed to send user token');
         }
     }
 }

--- a/app/Clients/Consumer/DTO/UserTokenDTO.php
+++ b/app/Clients/Consumer/DTO/UserTokenDTO.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Clients\Consumer\DTO;
+
+use App\DTO\AuthorizationDTO;
+
+readonly class UserTokenDTO
+{
+    public function __construct(
+        public AuthorizationDTO $authDTO,
+        public int $userId,
+    ) {}
+
+    public static function factory(AuthorizationDTO $authenticationDTO, int $userId): UserTokenDTO
+    {
+        return new UserTokenDTO(
+            authDTO: $authenticationDTO,
+            userId: $userId,
+        );
+    }
+}

--- a/app/DTO/AuthenticationDTO.php
+++ b/app/DTO/AuthenticationDTO.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\DTO;
+
+use App\Models\User;
+
+readonly class AuthenticationDTO
+{
+    public function __construct(
+        public AuthorizationDTO $authorization,
+        public User $user,
+    ) {}
+
+    public static function factory(AuthorizationDTO $authorization, User $user): AuthenticationDTO
+    {
+        return new AuthenticationDTO(
+            authorization: $authorization,
+            user: $user,
+        );
+    }
+}

--- a/app/DTO/AuthorizationDTO.php
+++ b/app/DTO/AuthorizationDTO.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\DTO;
+
+use Carbon\Carbon;
+
+readonly class AuthorizationDTO
+{
+    public function __construct(
+        public string $accessToken,
+        public Carbon $expiresAt,
+        public string $token = 'Bearer',
+    ) {}
+
+    public static function factory($accessToken, $expiresAt): AuthorizationDTO
+    {
+        return new AuthorizationDTO(
+            accessToken: $accessToken,
+            expiresAt: $expiresAt,
+        );
+    }
+}

--- a/app/DTO/AuthorizationDTO.php
+++ b/app/DTO/AuthorizationDTO.php
@@ -4,7 +4,7 @@ namespace App\DTO;
 
 use Carbon\Carbon;
 
-readonly class AuthorizationDTO
+readonly class AuthorizationDTO implements \JsonSerializable
 {
     public function __construct(
         public string $accessToken,
@@ -18,5 +18,14 @@ readonly class AuthorizationDTO
             accessToken: $accessToken,
             expiresAt: $expiresAt,
         );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'access_token' => $this->accessToken,
+            'token_type' => $this->token,
+            'expires_at' => $this->expiresAt->toIso8601String(),
+        ];
     }
 }

--- a/app/Http/Controllers/Api/V1/OAuthController.php
+++ b/app/Http/Controllers/Api/V1/OAuthController.php
@@ -2,53 +2,48 @@
 
 namespace App\Http\Controllers\Api\V1;
 
+use App\Clients\Consumer\ConsumerClient;
+use App\Clients\Consumer\DTO\UserTokenDTO;
+use App\DTO\AuthenticationDTO;
+use App\DTO\AuthorizationDTO;
 use App\Http\Controllers\Controller;
 use ChrisReedIO\Socialment\Exceptions\AbortedLoginException;
 use ChrisReedIO\Socialment\Facades\Socialment;
 use ChrisReedIO\Socialment\Models\ConnectedAccount;
-use Illuminate\Http\Request;
 use Laravel\Socialite\Facades\Socialite;
 
 class OAuthController extends Controller
 {
-    public function authenticateWithOAuth(Request $request, string $provider)
+    public function __construct(private readonly ConsumerClient $consumerClient) {}
+
+    public function authenticateWithOAuth(string $provider)
     {
         $socialUser = Socialite::driver($provider)
             ->stateless()
             ->user();
 
+        $response = $this->registerAndAuthenticate($provider, $socialUser);
+        $this->consumerClient->sendUserToken(UserTokenDTO::factory(
+            $response->authorization,
+            $response->user->id
+        ));
+
+        return response()->json($response);
+
+    }
+
+    public function registerAndAuthenticate(string $provider, $socialUser): AuthenticationDTO
+    {
         $tokenExpiration = $socialUser->expiresIn
             ? now()->addSeconds($socialUser->expiresIn)
             : null;
 
-        // Create a user or log them in...
-        $connectedAccount = ConnectedAccount::firstOrNew([
-            'provider' => $provider,
-            'provider_user_id' => $socialUser->getId(),
-        ], [
-            'name' => $socialUser->getName(),
-            'nickname' => $socialUser->getNickname(),
-            'email' => $socialUser->getEmail(),
-            'avatar' => $socialUser->getAvatar(),
-            'token' => $socialUser->token,
-            'refresh_token' => $socialUser->refreshToken,
-            'expires_at' => $tokenExpiration,
-        ]);
-
-        if (! $connectedAccount->exists) {
-            // Check for an existing user with this email
-            // Create a new user if one doesn't exist
-            $user = Socialment::createUser($connectedAccount);
-
-            if ($user === null) {
-                throw new AbortedLoginException('This account is not authorized to log in.');
-            }
-
-            // Associate the user and save this connected account
-            $connectedAccount->user()->associate($user)->save();
-        } else {
-            // Update the connected account with the latest data
-            $connectedAccount->update([
+        return \DB::transaction(function () use ($provider, $socialUser, $tokenExpiration) {
+            // Create a user or log them in...
+            $connectedAccount = ConnectedAccount::firstOrNew([
+                'provider' => $provider,
+                'provider_user_id' => $socialUser->getId(),
+            ], [
                 'name' => $socialUser->getName(),
                 'nickname' => $socialUser->getNickname(),
                 'email' => $socialUser->getEmail(),
@@ -57,20 +52,42 @@ class OAuthController extends Controller
                 'refresh_token' => $socialUser->refreshToken,
                 'expires_at' => $tokenExpiration,
             ]);
-        }
-        // AccessToken
-        $accessToken = $connectedAccount
-            ->user
-            ->createToken('authToken', ['*'], $tokenExpiration)
-            ->plainTextToken;
 
-        return response()->json([
-            'authorization' => [
-                'access_token' => $accessToken,
-                'token_type' => 'Bearer',
-                'expires_at' => $tokenExpiration,
-            ],
-            'user' => $connectedAccount->user->load(['settings' => fn ($query) => $query->with('occupation'), 'accounts']),
-        ]);
+            if (! $connectedAccount->exists) {
+                // Check for an existing user with this email
+                // Create a new user if one doesn't exist
+                $user = Socialment::createUser($connectedAccount);
+
+                if ($user === null) {
+                    throw new AbortedLoginException('This account is not authorized to log in.');
+                }
+
+                // Associate the user and save this connected account
+                $connectedAccount->user()->associate($user)->save();
+            } else {
+                // Update the connected account with the latest data
+                $connectedAccount->update([
+                    'name' => $socialUser->getName(),
+                    'nickname' => $socialUser->getNickname(),
+                    'email' => $socialUser->getEmail(),
+                    'avatar' => $socialUser->getAvatar(),
+                    'token' => $socialUser->token,
+                    'refresh_token' => $socialUser->refreshToken,
+                    'expires_at' => $tokenExpiration,
+                ]);
+            }
+            // AccessToken
+            $accessToken = $connectedAccount
+                ->user
+                ->createToken('authToken', ['*'], $tokenExpiration)
+                ->plainTextToken;
+
+            $user = $connectedAccount->user()->with(['settings.occupation', 'accounts'])->first();
+
+            return AuthenticationDTO::factory(
+                AuthorizationDTO::factory($accessToken, $tokenExpiration),
+                $user,
+            );
+        });
     }
 }

--- a/app/Models/Settings/Settings.php
+++ b/app/Models/Settings/Settings.php
@@ -24,7 +24,6 @@ class Settings extends Model
         'is_developer' => 'boolean',
     ];
 
-
     public function getPronounsAttribute(): array
     {
         return config('extension.pronouns.'.$this->attributes['pronouns']);

--- a/app/Models/Settings/Settings.php
+++ b/app/Models/Settings/Settings.php
@@ -21,11 +21,12 @@ class Settings extends Model
     ];
 
     protected $casts = [
-        'is_developer' => 'boolean'
+        'is_developer' => 'boolean',
     ];
 
-    public function getPronounsAttribute() {
-        return config('extension.pronouns.' . $this->attributes['pronouns']);
+    public function getPronounsAttribute(): array
+    {
+        return config('extension.pronouns.'.$this->attributes['pronouns']);
     }
 
     public function user(): BelongsTo

--- a/config/extension.php
+++ b/config/extension.php
@@ -3,7 +3,7 @@
 return [
     'pronouns' => [
         'none' => [
-            'name' => 'n/d',
+            'name' => 'None',
             'translation_key' => 'None',
             'slug' => 'none',
         ],

--- a/tests/Feature/Http/Controllers/Api/V1/AuthenticatedUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/V1/AuthenticatedUserControllerTest.php
@@ -47,7 +47,7 @@ class AuthenticatedUserControllerTest extends TestCase
             ->putJson(route('auth.update-settings'), $payload);
 
         // Assert
-        $payload['pronouns'] = config('extension.pronouns.' . $payload['pronouns']);
+        $payload['pronouns'] = config('extension.pronouns.'.$payload['pronouns']);
         $response->assertOk()
             ->assertJsonFragment($payload)
             ->assertJsonStructure(['occupation' => ['id']])


### PR DESCRIPTION
## Motivation

The Consumer API needs to get some verification token to validate if the user should send the metrics heartbeat.

Now the platform also syncs the user token which will expires together. 