### PR TITLE
fix(ci): eval assertion with boolean value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           DB_PORT: ${{ job.services.postgres.ports['5432'] }}
           REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
       - name: Run coverage tests
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.coverage }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.coverage == 'true' }}
         run: php artisan test --coverage --min=90
         env:
           DB_PORT: ${{ job.services.postgres.ports['5432'] }}


### PR DESCRIPTION
This PR fixes the evaluation of the `coverage` boolean value, which enables coverage and currently breaks the pipeline when started by `workflow_dispatch`, considering the previous assertion as true every time as seen on [action run](https://github.com/basementdevs/tbp-platform/actions/runs/11152550730)