### PR TITLE
ci: add step to get latest commit message for deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,20 +159,24 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Get the latest commit message
+        id: get_commit_message
+        run: |
+          echo "forge_deploy_message=$(git log -1 --pretty=%s)" >> "$GITHUB_OUTPUT"
       - name: Print GitHub Context
         run: |
           echo "### GitHub Context ###"
           echo "Event Name: ${{ github.event_name }}"
-          echo "Ref: ${{ github.ref }}"
-          echo "Branch Name: ${{ github.ref_name }}"
+          echo "Ref: ${{ github.ref_name }} | ${{ github.ref }}"
+          echo "Commit message: ${{ steps.get_commit_message.outputs.forge_deploy_message }}"
           echo "Commit Hash: ${{ github.sha }}"
-          echo "Actor: ${{ github.actor }}"
-          echo "Environment: ${{ vars.DEPLOY_ENV }}"
+          echo "Actor: @${{ github.actor }}"
       - name: Trigger Deployment on Laravel Forge
         env:
           FORGE_DEPLOY_BRANCH: ${{ github.ref_name }}
           FORGE_DEPLOY_COMMIT: ${{ github.sha }}
           FORGE_DEPLOY_AUTHOR: ${{ github.actor }}
+          FORGE_DEPLOY_MESSAGE: ${{ steps.get_commit_message.outputs.forge_deploy_message }}
         run: |
           curl -X POST \
             "https://forge.laravel.com/servers/${{ secrets.FORGE_SERVER_ID }}/sites/${{ secrets.FORGE_SITE_ID }}/deploy/http" \
@@ -180,4 +184,5 @@ jobs:
             --data-urlencode "forge_deploy_branch=${{ env.FORGE_DEPLOY_BRANCH }}" \
             --data-urlencode "forge_deploy_commit=${{ env.FORGE_DEPLOY_COMMIT }}" \
             --data-urlencode "forge_deploy_author=${{ env.FORGE_DEPLOY_AUTHOR }}" \
+            --data-urlencode "forge_deploy_message=${{ env.FORGE_DEPLOY_MESSAGE }}" \
             --data-urlencode "env=${{ vars.DEPLOY_ENV }}"


### PR DESCRIPTION
This PR allows to get the last commit title and send it to the deploy system, so that the correct information can be displayed on discord notifications.

![image](https://github.com/user-attachments/assets/d0177721-16cd-45d2-b8da-6ad07a0f1744)
