### PR TITLE
fix: get last deployment status

### DIFF
--- a/.github/actions/wait-deploy/action.yml
+++ b/.github/actions/wait-deploy/action.yml
@@ -40,7 +40,7 @@ runs:
             -H "Authorization: Bearer ${{ inputs.forge_api_token }}" \
             -H "Accept: application/json")
 
-          LATEST_DEPLOYMENT=$(echo "$RESPONSE" | tr -d '\r\n' | jq -r --arg LATEST_COMMIT "$LATEST_COMMIT" '.deployments[] | select(.commit_hash == $LATEST_COMMIT) | .status')
+          LATEST_DEPLOYMENT=$(echo "$RESPONSE" | tr -d '\r\n' | jq -r --arg LATEST_COMMIT "$LATEST_COMMIT" '.deployments | map(select(.commit_hash == $LATEST_COMMIT)) | sort_by(.started_at) | last | .status')
 
           STATUS=${LATEST_DEPLOYMENT:-"null"}
 


### PR DESCRIPTION
This pull request includes a change to the `runs:` section in the `.github/actions/wait-deploy/action.yml` file to improve the way the latest deployment status is determined.

Enhancements to deployment status determination:

* [`.github/actions/wait-deploy/action.yml`](diffhunk://#diff-1b951f48060fb12b155d7ff61125ec8403afb05b4facef0a6ef3373f9bcf8f31L43-R43): Modified the `LATEST_DEPLOYMENT` variable to use `map` and `sort_by` functions to select the deployment with the latest `started_at` timestamp, ensuring the correct deployment status is retrieved.