### PR TITLE
fix: ocuppation image_url generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+# Default target
+.DEFAULT_GOAL := help
+
+# Commands
+test: ## Run tests
+	@php artisan test
+
+coverage: ## Run tests with coverage
+	@php artisan test --coverage --min=90
+
+pint: ## Run Pint code style fixer
+	@$(CURDIR)/vendor/bin/pint --no-interaction --test --preset=laravel
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/app/Models/Settings/Occupation.php
+++ b/app/Models/Settings/Occupation.php
@@ -15,7 +15,7 @@ class Occupation extends Model
 
     public function getImageUrlAttribute(): string
     {
-        return sprintf('https://twitch-extension.danielheart.dev/static/icons/%s.png', $this->slug);
+        return sprintf('%s/static/icons/%s.png', config('services.consumer-api.base_uri'), $this->slug);
     }
 
     protected $appends = [

--- a/tests/Unit/app/Models/Settings/OccupationTest.php
+++ b/tests/Unit/app/Models/Settings/OccupationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\app\Models\Settings;
+
+use App\Models\Settings\Occupation;
+use App\Models\Settings\Settings;
+use Tests\TestCase;
+
+class OccupationTest extends TestCase
+{
+    public function testOccupationCanBeCreated()
+    {
+        Occupation::factory()->create([
+            'name' => 'Developer',
+            'slug' => 'developer',
+            'translation_key' => 'occupation.developer',
+        ]);
+
+        $this->assertDatabaseHas('occupations', [
+            'name' => 'Developer',
+            'slug' => 'developer',
+            'translation_key' => 'occupation.developer',
+        ]);
+    }
+
+    public function testImageUrlAttribute()
+    {
+        $occupation = Occupation::factory()->create([
+            'slug' => 'developer',
+        ]);
+
+        $expectedUrl = sprintf('%s/static/icons/developer.png', config('services.consumer-api.base_uri'));
+
+        $this->assertEquals($expectedUrl, $occupation->image_url);
+    }
+
+    public function testOccupationHasManySettings()
+    {
+        $occupation = Occupation::factory()->create();
+        $settings = Settings::factory()->create(['occupation_id' => $occupation->id]);
+
+        $this->assertTrue($occupation->settings->contains($settings));
+    }
+}


### PR DESCRIPTION
This pull request will fix a bug from ocuppation image url, since old domain has been removed, currently it shows an image of broken file.

![image](https://github.com/user-attachments/assets/ae06af98-aa59-4e54-855d-46e775212986)

I also add a simple Makefile to run the tests and format the code.

![image](https://github.com/user-attachments/assets/c217d767-c0ba-42d5-a7ba-be56834b1500)
